### PR TITLE
chore: remove Yarn security settings; add build:netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 dev-dist
+netlify
 coverage
 *.local
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,11 +1,6 @@
-approvedGitRepositories:
-  - "**"
-
 compressionLevel: mixed
 
 enableGlobalCache: true
-
-enableScripts: true
 
 nodeLinker: node-modules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ A vanilla JS progressive web app (PWA) for solving cryptogram puzzles. No framew
 ```bash
 yarn dev              # dev server with PWA enabled (http://localhost:3050)
 yarn build            # production build → dist/
+yarn build:netlify    # dual build → netlify/ and netlify/cryptogram/
 yarn preview          # preview the production build locally
 yarn format           # Prettier — reformat all files in place
 yarn format:check     # Prettier — check only (used by pre-commit hook and CI)
@@ -116,10 +117,8 @@ After changing dependencies, commit the updated `yarn.lock` together.
 
 ## Build output
 
-`yarn build` produces two output directories (both committed to `dist/` on deploy):
-
-- `dist/` — root output
-- `dist/cryptogram/` — subdirectory build for Netlify deployment under `/cryptogram/`
+- `yarn build` → `dist/` (standard Vite output)
+- `yarn build:netlify` → `netlify/` (root) + `netlify/cryptogram/` (subdirectory for Netlify deployment under `/cryptogram/`); `netlify/` is gitignored
 
 The `base: './'` in [vite.config.ts](vite.config.ts) ensures asset paths are relative.
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:netlify": "vite build --outDir netlify && vite build --outDir netlify/cryptogram",
     "preview": "vite preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,14 +7,6 @@ export default defineConfig({
   server: {
     port: 3050,
   },
-  build: {
-    rollupOptions: {
-      output: [
-        { dir: "dist" },
-        { dir: "dist/cryptogram" }, // For Netlify subdirectory
-      ],
-    },
-  },
   plugins: [
     VitePWA({
       registerType: "autoUpdate",


### PR DESCRIPTION
## Summary

- **YARN-SEC**: Removes `enableScripts: true` and `approvedGitRepositories: ["**"]` from `.yarnrc.yml` — neither setting is needed (no lifecycle scripts, no git-sourced deps) and both widen the supply-chain attack surface unnecessarily
- **NETLIFY**: Adds `build:netlify` script (`vite build --outDir netlify && vite build --outDir netlify/cryptogram`) matching the pattern used by `order`/`currency`
- Removes the now-redundant dual `rollupOptions.output` array from `vite.config.ts` (the script handles both output dirs)
- Adds `netlify/` to `.gitignore`
- Updates CLAUDE.md commands table and build output section

## Test plan

- [ ] `yarn build` — standard `dist/` output still works
- [ ] `yarn build:netlify` — produces `netlify/` and `netlify/cryptogram/` with full PWA artefacts
- [ ] Pre-commit hook passed (format:check + lint + tests all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)