### PR TITLE
Add axe accessibility testing, Playwright E2E, bump CI Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -26,3 +26,20 @@ jobs:
       - run: yarn build
 
       - run: yarn test:coverage
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: yarn playwright install-deps chromium
+
+      - run: yarn test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ netlify
 coverage
 *.local
 
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,12 @@ yarn build:netlify    # dual build → netlify/ and netlify/cryptogram/
 yarn preview          # preview the production build locally
 yarn format           # Prettier — reformat all files in place
 yarn format:check     # Prettier — check only (used by pre-commit hook and CI)
-yarn lint             # ESLint (src/ only)
+yarn lint             # ESLint (src/, e2e/, playwright.config.js)
 yarn lint:fix         # ESLint with auto-fix
 yarn test             # Vitest in watch mode
 yarn test:run         # Vitest single pass (used by pre-commit hook and CI)
 yarn test:coverage    # Vitest single pass with v8 coverage report → coverage/
+yarn test:e2e         # Playwright E2E suite (CI only, not pre-commit)
 ```
 
 ## Architecture
@@ -40,6 +41,8 @@ src/
     styles.scss        # App-specific styles, BEM-ish naming, dark mode via @media
   test/
     setup.js           # jsdom HTML fixture — runs before all tests via vitest setupFiles
+e2e/
+  cryptogram.spec.js   # Playwright E2E — solve/clear/new-puzzle golden paths against a real browser
 index.html             # Static shell — all sections present in HTML, shown/hidden via JS
 ```
 
@@ -78,6 +81,8 @@ index.html             # Static shell — all sections present in HTML, shown/hi
 | Vitest                 | ^4            | Test runner (jsdom environment)                       |
 | @vitest/coverage-v8    | ^4            | V8 coverage reports                                   |
 | @vitest/eslint-plugin  | ^1            | ESLint globals for test files                         |
+| axe-core               | ^4            | Accessibility checks run directly against jsdom       |
+| @playwright/test       | ^1            | E2E testing (Chromium only), CI-only                  |
 | Husky                  | ^9            | Git hooks                                             |
 
 ## Code style
@@ -139,9 +144,13 @@ Tests are co-located with source files (`*.test.js`). The jsdom environment is c
 
 Current coverage: **100%** statements, branches, functions, and lines.
 
+[src/scripts/accessibility.test.js](src/scripts/accessibility.test.js) runs `axe-core` directly against jsdom (no browser) using the real `index.html` markup — both the entry screen and a started puzzle. `color-contrast` is disabled since jsdom doesn't perform layout/rendering.
+
+[e2e/cryptogram.spec.js](e2e/cryptogram.spec.js) is a Playwright suite (Chromium only) that drives the real dev server through the solve/clear/new-puzzle golden paths. It runs in CI only (`yarn test:e2e`), not in the pre-commit hook — browser install + startup is too slow for a hook. Excluded from Vitest's test glob via `exclude: ["e2e/**"]` in [vitest.config.js](vitest.config.js).
+
 The pre-commit hook (`.husky/pre-commit`) runs `yarn format:check && yarn lint && yarn test:run` before every commit. The `prepare` script ensures Husky is installed automatically after `yarn install`.
 
-The GitHub Actions workflow at [.github/workflows/test.yml](.github/workflows/test.yml) runs lint and tests on every push to `main` and on every PR.
+The GitHub Actions workflow at [.github/workflows/test.yml](.github/workflows/test.yml) runs format:check → lint → build → test:coverage → Playwright E2E on every push to `main` and on every PR. Playwright's Chromium binary is cached by `yarn.lock` hash.
 
 ## Dependency maintenance
 
@@ -150,7 +159,7 @@ The GitHub Actions workflow at [.github/workflows/test.yml](.github/workflows/te
 - When reviewing Dependabot PRs, check whether the alert is already resolved by a `resolutions` entry before merging redundant bumps
 - Node.js target is the current Active LTS — update `.nvmrc` when a new LTS is released
 
-## Modernization status (assessed 2026-06-16)
+## Modernization status (assessed 2026-07-13)
 
 Cryptogram meets the cross-repo standard baseline.
 
@@ -166,11 +175,14 @@ Cryptogram meets the cross-repo standard baseline.
 - `.github/workflows/test.yml` — format:check → lint → build → test:coverage on PR + push to `main`
 - `.github/CODEOWNERS` — `* @craigmcn`
 - Branch protection ([ruleset](https://github.com/craigmcn/cryptogram/rules/14954844)) — 1 required approval, Admin role bypass, dismiss stale reviews, require `test` status check, block deletions + force pushes
+- GitHub Actions bumped to current majors — `actions/checkout@v7`, `actions/setup-node@v6`, `actions/cache@v6` (issue #70)
+- axe-core accessibility testing — direct against jsdom, vanilla JS pattern; caught and fixed a real gap (solution inputs had no accessible label) (issue #71)
+- Playwright E2E testing — Chromium only, CI-only, golden-path coverage of solve/clear/new-puzzle (issue #72)
 
 **Outstanding TODOs:**
 
 - **PR #68** (open) — security resolutions for vite, js-yaml, tar, @babel/core; awaiting review and merge
-- Remaining TODOs (vite-plugin-pwa 1.x upgrade, Vite 8 upgrade, both blocked upstream; GitHub Actions bump; axe tooling; Playwright E2E) tracked as issues in the [cryptogram GitHub Project](https://github.com/users/craigmcn/projects/3)
+- Remaining TODOs (vite-plugin-pwa 1.x upgrade, Vite 8 upgrade, both blocked upstream) tracked as issues in the [cryptogram GitHub Project](https://github.com/users/craigmcn/projects/3)
 
 **Key decisions:**
 

--- a/e2e/cryptogram.spec.js
+++ b/e2e/cryptogram.spec.js
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+test("solving a puzzle from start to completion", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByLabel("Enter your cryptogram").fill("Uifsf jt op tqppo.");
+  await page.getByRole("button", { name: "Start" }).click();
+
+  const puzzleInputs = page.locator(".solution__input");
+  await expect(puzzleInputs).toHaveCount(14);
+
+  const solution = "There is no spoon.".toUpperCase().replace(/[^A-Z]/g, "");
+  const cipher = "Uifsf jt op tqppo".toUpperCase().replace(/[^A-Z]/g, "");
+
+  for (let i = 0; i < cipher.length; i++) {
+    await puzzleInputs.nth(i).fill(solution[i]);
+  }
+
+  await expect(page.locator(".solution")).toHaveClass(/solution--complete/);
+  await expect(page.locator('[data-letter="T"]')).toHaveClass(/used/);
+});
+
+test("clear resets the guessed letters without leaving the puzzle", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByLabel("Enter your cryptogram").fill("Uifsf jt op tqppo.");
+  await page.getByRole("button", { name: "Start" }).click();
+
+  const puzzleInputs = page.locator(".solution__input");
+  await puzzleInputs.first().fill("T");
+  await expect(puzzleInputs.first()).toHaveValue("T");
+
+  await page.getByRole("button", { name: "Clear" }).click();
+
+  await expect(puzzleInputs.first()).toHaveValue("");
+  await expect(page.locator(".solution")).toBeVisible();
+});
+
+test("new puzzle returns to the entry screen", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByLabel("Enter your cryptogram").fill("Uifsf jt op tqppo.");
+  await page.getByRole("button", { name: "Start" }).click();
+  await expect(page.locator(".solution__input").first()).toBeVisible();
+
+  await page.getByRole("button", { name: "New puzzle" }).click();
+
+  await expect(page.getByLabel("Enter your cryptogram")).toBeVisible();
+  await expect(page.getByLabel("Enter your cryptogram")).toHaveValue("");
+});

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "preview": "vite preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix",
+    "lint": "eslint ./src ./e2e playwright.config.js",
+    "lint:fix": "eslint ./src ./e2e playwright.config.js --fix",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "prepare": "husky"
   },
   "repository": {
@@ -31,8 +32,10 @@
   "author": "Craig McNaughton",
   "license": "GPL-3.0-or-later",
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@vitest/coverage-v8": "^4.1.4",
     "@vitest/eslint-plugin": "^1.6.15",
+    "axe-core": "^4.12.1",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3050",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "yarn dev",
+    url: "http://localhost:3050",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/scripts/accessibility.test.js
+++ b/src/scripts/accessibility.test.js
@@ -3,10 +3,14 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import axe from "axe-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const indexHtml = readFileSync(resolve(process.cwd(), "index.html"), "utf-8");
-const bodyMarkup = indexHtml.match(/<body>([\s\S]*)<\/body>/)[1];
+const bodyMatch = indexHtml.match(/<body[^>]*>([\s\S]*)<\/body>/);
+if (!bodyMatch) {
+  throw new Error("Could not find a <body> element in index.html");
+}
+const bodyMarkup = bodyMatch[1];
 
 // jsdom doesn't perform layout/rendering, so rules that depend on it
 // (color contrast, actual visibility) can't be evaluated meaningfully.
@@ -16,8 +20,11 @@ const axeOptions = {
   },
 };
 
+// actions.js captures its DOM elements once at module scope, so every test
+// needs its own fresh module instance bound to that test's own fixture.
 describe("accessibility", () => {
   it("has no axe violations on the initial start screen", async () => {
+    vi.resetModules();
     document.body.innerHTML = bodyMarkup;
     await import("./index.js");
 
@@ -26,6 +33,7 @@ describe("accessibility", () => {
   });
 
   it("has no axe violations once a puzzle is started", async () => {
+    vi.resetModules();
     document.body.innerHTML = bodyMarkup;
     const { start } = await import("./actions.js");
 

--- a/src/scripts/accessibility.test.js
+++ b/src/scripts/accessibility.test.js
@@ -1,0 +1,38 @@
+// Runs axe-core directly against jsdom (no browser) using the real
+// index.html markup, so violations are caught without a Playwright run.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import axe from "axe-core";
+import { describe, expect, it } from "vitest";
+
+const indexHtml = readFileSync(resolve(process.cwd(), "index.html"), "utf-8");
+const bodyMarkup = indexHtml.match(/<body>([\s\S]*)<\/body>/)[1];
+
+// jsdom doesn't perform layout/rendering, so rules that depend on it
+// (color contrast, actual visibility) can't be evaluated meaningfully.
+const axeOptions = {
+  rules: {
+    "color-contrast": { enabled: false },
+  },
+};
+
+describe("accessibility", () => {
+  it("has no axe violations on the initial start screen", async () => {
+    document.body.innerHTML = bodyMarkup;
+    await import("./index.js");
+
+    const results = await axe.run(document.body, axeOptions);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("has no axe violations once a puzzle is started", async () => {
+    document.body.innerHTML = bodyMarkup;
+    const { start } = await import("./actions.js");
+
+    document.getElementById("cryptogram-text").value = "Uifsf jt op tqppo.";
+    start({ preventDefault: () => {} });
+
+    const results = await axe.run(document.body, axeOptions);
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/src/scripts/actions.js
+++ b/src/scripts/actions.js
@@ -130,7 +130,7 @@ const initCryptogram = () => {
           ? ` value="${escapedValue}" data-old-value="${escapedValue}"`
           : "";
         const input = l.match(/[A-Z]/)
-          ? `<input class="solution__input" type="text" maxlength="2"${value} data-puzzle="${l}">`
+          ? `<input class="solution__input" type="text" maxlength="2"${value} data-puzzle="${l}" aria-label="Guess for cipher letter ${l}">`
           : escapeHtml(l);
 
         return `<div class="flex flex--column"><div class="solution__item flex flex--ai-end flex--jc-center">${input}</div><div class="solution__puzzle">${escapeHtml(l)}</div></div>`;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,10 +1,10 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./src/test/setup.js"],
-    exclude: ["**/node_modules/**", "e2e/**"],
+    exclude: [...configDefaults.exclude, "e2e/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./src/test/setup.js"],
+    exclude: ["**/node_modules/**", "e2e/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,6 +2261,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.61.1":
+  version: 1.61.1
+  resolution: "@playwright/test@npm:1.61.1"
+  dependencies:
+    playwright: "npm:1.61.1"
+  bin:
+    playwright: cli.js
+  checksum: 10/08915357031e1bc273a19bb428fb7e51031ca44f25750832e389bcd69c399f6a243f5f832e7832d46153b57b1305f1f5f5dd63f3a3261f928f61e464c6b3c64e
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-babel@npm:^5.2.0":
   version: 5.3.1
   resolution: "@rollup/plugin-babel@npm:5.3.1"
@@ -3125,6 +3136,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axe-core@npm:^4.12.1":
+  version: 4.12.1
+  resolution: "axe-core@npm:4.12.1"
+  checksum: 10/08c2ff348524b57dfb68f4e866b1a6363147203b721c734ed00090c16eb911cd015cf71fd96a8bafe42609715f649d21b2e188fae622ac8ef6144b144582f6c4
+  languageName: node
+  linkType: hard
+
 "babel-plugin-polyfill-corejs2@npm:^0.3.3":
   version: 0.3.3
   resolution: "babel-plugin-polyfill-corejs2@npm:0.3.3"
@@ -3497,8 +3515,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cryptogram@workspace:."
   dependencies:
+    "@playwright/test": "npm:^1.61.1"
     "@vitest/coverage-v8": "npm:^4.1.4"
     "@vitest/eslint-plugin": "npm:^1.6.15"
+    axe-core: "npm:^4.12.1"
     eslint: "npm:^9.0.0"
     eslint-config-prettier: "npm:^10.1.8"
     husky: "npm:^9.1.7"
@@ -4430,7 +4450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
+"fsevents@npm:2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -4450,7 +4470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
@@ -6275,6 +6295,30 @@ __metadata:
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright-core@npm:1.61.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10/b0e7b1d4de7ca6c1a57eb88f1709609a8b7637092f149e703d84d6c8e01835992ec5ca26b86f1a32fb5f5bc1aad042c3ae27311e131b3dda8a27824a543eb3c7
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright@npm:1.61.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.61.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10/0cd1a8a7e106202e785450763973bf326d4aa112ed195bbd78b17af43dcfd12e29bc8204ae61c88f748dd0f2bdf69a7827bc3bbf8c1ec4c71b8e35586e05f13c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` (v4→v7), `actions/setup-node` (v4→v6), and adds `actions/cache@v6` for the new Playwright browser cache (#70)
- Adds `axe-core` run directly against jsdom on the real `index.html` markup (both the entry screen and a started puzzle) — no browser needed. This caught a genuine bug: the dynamically-generated puzzle inputs had no accessible label, now fixed with `aria-label` (#71)
- Adds a Playwright E2E suite (Chromium only, CI-only per the cross-repo pattern) covering solve → complete, clear, and new-puzzle golden paths (#72)
- Folds in the corresponding CLAUDE.md checkpoint update

Bundled into one branch/PR since all three are small, additive, low-risk testing/CI changes with no overlap.

## Test plan
- [x] `yarn format:check && yarn lint && yarn build` all pass
- [x] `yarn test:coverage` — 70/70 tests pass, 100% coverage maintained
- [x] `yarn test:e2e` — 3/3 Playwright tests pass against the real dev server
- [x] CI workflow updated to run the new Playwright step with browser caching

Closes #70, closes #71, closes #72