### PR TITLE
chore(deps): pin brace-expansion to ^5.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "packageManager": "yarn@4.14.1",
   "resolutions": {
     "@babel/core": "^7.29.6",
+    "brace-expansion": "^5.0.7",
     "ejs": "^5.0.1",
     "js-yaml": "^4.3.0",
     "node-gyp": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "packageManager": "yarn@4.14.1",
   "resolutions": {
     "@babel/core": "^7.29.6",
-    "brace-expansion": "^5.0.7",
+    "brace-expansion@npm:^5.0.5": "^5.0.7",
     "ejs": "^5.0.1",
     "js-yaml": "^4.3.0",
     "node-gyp": "^12.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3179,13 +3179,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "balanced-match@npm:1.0.2"
-  checksum: 10/9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -3218,22 +3211,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-    concat-map: "npm:0.0.1"
-  checksum: 10/94498bead66c51536df5b7bf1b0a0e581a5b7f86888be10481d06920c4bd9d976e003b13a3d19fddc733f21a09d162ff72f90e18b2c9d062b15121e973d0e13b
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:^5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
   languageName: node
   linkType: hard
 
@@ -3467,13 +3450,6 @@ __metadata:
   version: 1.8.2
   resolution: "common-tags@npm:1.8.2"
   checksum: 10/c665d0f463ee79dda801471ad8da6cb33ff7332ba45609916a508ad3d77ba07ca9deeb452e83f81f24c2b081e2c1315347f23d239210e63d1c5e1a0c7c019fe2
-  languageName: node
-  linkType: hard
-
-"concat-map@npm:0.0.1":
-  version: 0.0.1
-  resolution: "concat-map@npm:0.0.1"
-  checksum: 10/9680699c8e2b3af0ae22592cb764acaf973f292a7b71b8a06720233011853a58e256c89216a10cbe889727532fd77f8bcd49a760cedfde271b8e006c20e079f2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3179,6 +3179,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "balanced-match@npm:1.0.2"
+  checksum: 10/9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -3208,6 +3215,16 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: 10/ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^1.1.7":
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
+  checksum: 10/94498bead66c51536df5b7bf1b0a0e581a5b7f86888be10481d06920c4bd9d976e003b13a3d19fddc733f21a09d162ff72f90e18b2c9d062b15121e973d0e13b
   languageName: node
   linkType: hard
 
@@ -3450,6 +3467,13 @@ __metadata:
   version: 1.8.2
   resolution: "common-tags@npm:1.8.2"
   checksum: 10/c665d0f463ee79dda801471ad8da6cb33ff7332ba45609916a508ad3d77ba07ca9deeb452e83f81f24c2b081e2c1315347f23d239210e63d1c5e1a0c7c019fe2
+  languageName: node
+  linkType: hard
+
+"concat-map@npm:0.0.1":
+  version: 0.0.1
+  resolution: "concat-map@npm:0.0.1"
+  checksum: 10/9680699c8e2b3af0ae22592cb764acaf973f292a7b71b8a06720233011853a58e256c89216a10cbe889727532fd77f8bcd49a760cedfde271b8e006c20e079f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Adds a scoped `resolutions` entry, `"brace-expansion@npm:^5.0.5": "^5.0.7"`, resolving Dependabot alert #102 ([GHSA-3jxr-9vmj-r5cp](https://github.com/craigmcn/cryptogram/security/dependabot/102), high) — DoS via exponential-time expansion of consecutive non-expanding `{}` groups.
- The vulnerable version (`5.0.5`) is pulled in transitively via `minimatch@10.2.5` (from `@typescript-eslint/typescript-estree`, a `neostandard` dependency, and `glob`) — lint/build tooling only, not shipped runtime code.
- **Scoped, not blanket, resolution:** an earlier version of this PR used an unscoped `"brace-expansion": "^5.0.7"` entry, which forces *every* consumer onto 5.0.7 — including `minimatch@3.1.5` (used by `eslint`, `eslint-plugin-react`, `glob@7.2.3`), which is written against the 1.x API (callable default export) that 5.x replaced with a named export. That broke `minimatch@3.1.5`'s brace-pattern matching (`expand is not a function`). Scoping the resolution to the exact vulnerable descriptor patches only the affected line and leaves `minimatch@3.1.5` on its unaffected 1.x `brace-expansion` (outside the advisory's vulnerable range of `>=3.0.0 <5.0.7`).

## Test plan
- [x] `yarn install` resolves `minimatch@10.2.5` → `brace-expansion@5.0.7`, `minimatch@3.1.5` → `brace-expansion@1.1.16`
- [x] Verified `minimatch('a.js', '{a,b}.js')` no longer throws under `minimatch@3.1.5`
- [x] `yarn format:check`
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test:run` (70/70 passing, run on Node 24.14.1 per `.nvmrc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)